### PR TITLE
Remove skipping of ZIP files for file upload

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -55,9 +55,6 @@ def upload_files():
         for file in files:
             file_path = os.path.join(root, file)
             rel_file_path = os.path.relpath(file_path, "./files/default")
-            if file.endswith(".zip"):
-                print("Skipping file: " + rel_file_path)
-                continue
             print("Uploading file: " + rel_file_path)
             file_upload_url = api.client.servers.files.get_upload_file_url(
                 server)


### PR DESCRIPTION
Due to how some servers back up the world, the ZIP file has the most intact worlds. The ZIPs should be uploaded alongside the server as well as if there are any other files archived into ZIP files.