### PR TITLE
Add local and remote deletion of files during runtime

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import shutil
 import sys
 import time
 import requests
@@ -28,8 +29,10 @@ def main():
     """
     download_ftp()
     stop_server()
+    delete_remote_files()
     upload_files()
     start_server()
+    delete_local_files()
 
 
 def download_ftp():
@@ -95,32 +98,25 @@ def start_server():
     api.client.servers.send_power_action(server, "start")
     print("Server started")
 
-def delete_files():
+def delete_remote_files():
     """_summary_ Deletes files from the files directory
     """
     print("Deleting files on mirrored instance...")
-    # Because pydactyl is terrible with deleting files, we have to do it manually using the API
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + staging_api_key
-    }
-    data = {
-        "root": "/",
-        "files": [""]
-    }
+    dict_files = api.client.servers.files.list_files(server, "/")
+    file_names = []
+    for file in dict_files["data"]:
+        file_names.append(file["attributes"]["name"])
 
-    response = requests.post(staging_server, headers=headers, json=data)
-    print(response.status_code)  # prints the status code of the response
-    print(response.json())  # prints the JSON content of the response
+    api.client.servers.files.delete_files(server, file_names, "/")
 
     print("Files deleted")
 
-def cleanup_local_files():
+def delete_local_files():
     """_summary_ Deletes files from the files directory
     """
     print("Deleting local files...")
-    os.rmdir("./files")
-    print("Files deleted")
+    shutil.rmtree("./files")
+    print("Local files deleted")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Added functions to delete files remotely on the server and locally after uploads.

This will help with preventing overwriting and corruption of data, such as multiple plugin versions in the `plugins/` directory.